### PR TITLE
Fixed compatibility with other plugins using DOM click events

### DIFF
--- a/src/mousedownHandler.ts
+++ b/src/mousedownHandler.ts
@@ -46,7 +46,6 @@ export function getClickHandler(plugin: TableEnhancer2) {
 		const cellEl = getEditableNode(e.targetNode);
 		if (!cellEl) return;
 		// 否则是点击了某个单元格
-		e.stopImmediatePropagation();
 		e.preventDefault();
 		// 确定这个单元格所属的 table
 		let tableEl = cellEl.parentNode;


### PR DESCRIPTION
## Why am I making this PR?

Your plugin prevented other global click events from other plugins from activating. The use of **stopImmediatePropagation()** and the fact that you implemented the clickHandler in the capture phase makes it impossible for other plugins to have their click events triggered.

## Changes

- Removed [stopImmediatePropagation() ](https://github.com/Stardusten/ob-table-enhancer/blob/3a24fad9a19d26d7927dd2ffc58d536b8e5cc054/src/mousedownHandler.ts#L36)