### PR TITLE
Automated release by using tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Plugin release
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: npm build
+        run: |
+          npm install
+          npm run build --if-present
+      - name: Plugin release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          artifacts: "main.js,manifest.json,styles.css"
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With this pr, you can add tags to commits, and an automatic release gets created with main.js, manifest.json, and styles.css.
You must grant github actions write permissions in the settings to make this work.
![image](https://user-images.githubusercontent.com/70213368/219152634-05534909-8d19-4fea-ba38-6f5abe5fb454.png)
