### PR TITLE
misc: fix plugin version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "ob-table-enhancer",
 	"name": "Table Enhancer",
-	"version": "0.5.10",
+	"version": "0.5.11",
 	"minAppVersion": "0.15.0",
 	"description": "Manipulate markdown tables without touching the source code in Obsidian.",
 	"author": "Stardust",


### PR DESCRIPTION
There was a mismatch between the last release tag and the manifest version. I updated it manually to fix error with BRAT.